### PR TITLE
Employee registration function addition

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -13,8 +13,6 @@ class EmployeesController < ApplicationController
   def create
     @employee = Employee.new(employee_params)
 
-    add_params
-
     if @employee.save
       redirect_to employees_url, notice: "社員「#{@employee.last_name} #{@employee.first_name}」を登録しました。"
     else
@@ -26,8 +24,6 @@ class EmployeesController < ApplicationController
   end
 
   def update
-    add_params
-
     if @employee.update(employee_params)
       redirect_to employees_url, notice: "社員「#{@employee.last_name} #{@employee.first_name}」を更新しました。"
     else
@@ -48,7 +44,7 @@ class EmployeesController < ApplicationController
   private
 
   def employee_params
-    params.require(:employee).permit(:number, :last_name, :first_name, :account, :password, :department_id, :office_id, :employee_info_manage_auth)
+    params.require(:employee).permit(:number, :last_name, :first_name, :account, :password, :department_id, :office_id, :email, :date_of_joining, :employee_info_manage_auth)
   end
 
   def set_employee
@@ -58,16 +54,6 @@ class EmployeesController < ApplicationController
   def set_form_option
     @departments = Department.all
     @offices = Office.all
-  end
-
-  # 現在、メールアドレスと入社日は入力できないため、ここで追加しています。
-  def add_params
-    unless @employee.email
-      @employee.email = 'sample@example.com'
-    end
-    unless @employee.date_of_joining
-      @employee.date_of_joining = Date.today
-    end
   end
 
   def sort_column

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -44,7 +44,7 @@ class EmployeesController < ApplicationController
   private
 
   def employee_params
-    params.require(:employee).permit(:number, :last_name, :first_name, :account, :password, :department_id, :office_id, :email, :date_of_joining, :employee_info_manage_auth)
+    params.require(:employee).permit(:number, :last_name, :first_name, :account, :password, :department_id, :office_id, :email, :date_of_joining, :employee_info_manage_auth, :news_posting_auth)
   end
 
   def set_employee

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -8,6 +8,8 @@ class Employee < ApplicationRecord
   validates :first_name, presence: true
   validates :account, presence: true, uniqueness: true
   validates :password, presence: true
+  validates :email, presence: true
+  validates :date_of_joining, presence: true
 
   scope :active, -> {
     where(deleted_at: nil)

--- a/app/views/employees/_form.html.erb
+++ b/app/views/employees/_form.html.erb
@@ -39,6 +39,7 @@
       <%= f.label :date_of_joining %>
       <%= f.date_field :date_of_joining %>
     </div>
+
     <div class="form_group">
       <%= f.label :department_id %>
       <%= f.collection_select(:department_id, @departments, :id, :name)%>
@@ -54,6 +55,10 @@
       <%= f.check_box :employee_info_manage_auth, :as => :boolean %>
     </div>
 
+    <div class="form_group">
+      <%= f.label :news_posting_auth, class: 'checkbox_label' %>
+      <%= f.check_box :news_posting_auth, :as => :boolean %>
+    </div>
     <%= f.submit '保存' %>
   <% end %>
 </div>

--- a/app/views/employees/_form.html.erb
+++ b/app/views/employees/_form.html.erb
@@ -6,7 +6,6 @@
       <% end %>
     </ul>
   <% end %>
-
   <%= form_with model: employee, local: true do |f| %>
     <div class="form_group">
       <%= f.label :number %>
@@ -31,6 +30,15 @@
       <%= f.password_field :password %>
     </div>
 
+    <div class="form_group">
+      <%= f.label :email %>
+      <%= f.email_field :email %>
+    </div>
+
+    <div class="form_group">
+      <%= f.label :date_of_joining %>
+      <%= f.date_field :date_of_joining %>
+    </div>
     <div class="form_group">
       <%= f.label :department_id %>
       <%= f.collection_select(:department_id, @departments, :id, :name)%>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -33,5 +33,6 @@ ja:
         department_id: 部署
         office_id: オフィス
         employee_info_manage_auth: 社員情報管理権限
+        news_posting_auth: お知らせ投稿権限
       profile:
         profile: プロフィール

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -28,7 +28,7 @@ ja:
         first_name: 氏名（名）
         account: アカウント
         password: パスワード
-        e_mail: メールアドレス
+        email: メールアドレス
         date_of_joining: 入社年月日
         department_id: 部署
         office_id: オフィス

--- a/db/migrate/20230201103621_add_news_posting_auth_to_employee.rb
+++ b/db/migrate/20230201103621_add_news_posting_auth_to_employee.rb
@@ -1,0 +1,5 @@
+class AddNewsPostingAuthToEmployee < ActiveRecord::Migration[6.1]
+  def change
+    add_column :employees, :news_posting_auth, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_20_112406) do
+ActiveRecord::Schema.define(version: 2023_02_01_103621) do
 
   create_table "departments", force: :cascade do |t|
     t.string "name", null: false
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2021_10_20_112406) do
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "news_posting_auth", default: false, null: false
     t.index ["department_id"], name: "index_employees_on_department_id"
     t.index ["office_id"], name: "index_employees_on_office_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,4 +15,4 @@ Employee.find_or_create_by(id: 1, department_id: Department.find_by(name: '総�
                            office_id: Office.find_by(name: '東京').id,
                            number: '1', last_name: '山田', first_name: '太郎', account: 'yamada',
                            password: 'hogehoge', email: 'yamada@example.co.jp', date_of_joining: '1991/4/1',
-                           employee_info_manage_auth: true)
+                           employee_info_manage_auth: true, news_posting_auth: true)


### PR DESCRIPTION
### 社員登録ページの項目追加

- フォーム項目にメールアドレス、 入社日、お知らせ投稿権限の項目追加
app/views/employees/_form.html.erb

- employeesテーブルにnews_posting_auth（お知らせ投稿権限）の追加
db/migrate/20230201103621_add_news_posting_auth_to_employee.rb

- 初期データにお知らせ投稿権限の追加
db/seeds.rb

- 追加項目の日本語化
config/locales/ja.yml

- 追加項目バリデーション登録
app/models/employee.rb

- paramsの追加項目登録とメールアドレス、入社日自動追加の削除
app/controllers/employees_controller.rb